### PR TITLE
I've updated the Spring Boot parent to version 3.5.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.0</version>
+		<version>3.5.0</version> <!-- Updated version -->
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
This change also updated related dependencies such as spring-boot-starter-web, spring-boot-starter-data-jpa, and h2.

After the update, I confirmed that the project builds successfully and all tests pass, so there don't appear to be any immediate compatibility issues.